### PR TITLE
fix: handle null availability in therapist form

### DIFF
--- a/src/components/therapists/AdminTherapistsView.tsx
+++ b/src/components/therapists/AdminTherapistsView.tsx
@@ -358,7 +358,17 @@ export function AdminTherapistsView() {
                     languages: (editingTherapist.languages as string[]) || ['English'],
                     ageGroupExpertise: (editingTherapist.ageGroupExpertise as Array<'early_childhood' | 'school_age' | 'adolescent' | 'adult'>) || [],
                     communicationExpertise: (editingTherapist.communicationExpertise as Array<'non-verbal' | 'aac' | 'sign_language' | 'speech_integration'>) || [],
-                    availability: editingTherapist.availability as any,
+                    availability: editingTherapist.availability && typeof editingTherapist.availability === 'object'
+                      ? editingTherapist.availability
+                      : {
+                          monday: [],
+                          tuesday: [],
+                          wednesday: [],
+                          thursday: [],
+                          friday: [],
+                          saturday: [],
+                          sunday: [],
+                        },
                     specializations: editingTherapist.specializations?.map(s => ({
                       specializationId: s.specializationId,
                       proficiencyLevel: s.proficiencyLevel as 'expert' | 'proficient' | 'familiar',

--- a/src/components/therapists/TherapistProfileForm.tsx
+++ b/src/components/therapists/TherapistProfileForm.tsx
@@ -82,7 +82,9 @@ export function TherapistProfileForm({
     (initialData?.communicationExpertise as Array<'non-verbal' | 'aac' | 'sign_language' | 'speech_integration'>) || [],
   );
   const [availability, setAvailability] = useState<WeeklyAvailability>(
-    (initialData?.availability as WeeklyAvailability) || defaultAvailability,
+    initialData?.availability && typeof initialData.availability === 'object'
+      ? (initialData.availability as WeeklyAvailability)
+      : defaultAvailability,
   );
   const [selectedSpecializations, setSelectedSpecializations] = useState<
     Array<{ specializationId: string; proficiencyLevel: 'expert' | 'proficient' | 'familiar'; yearsExperience: number | null }>
@@ -604,7 +606,7 @@ export function TherapistProfileForm({
                 </Button>
               </div>
               <div className="space-y-2">
-                {availability[day].map((slot, index) => (
+                {(availability[day] || []).map((slot, index) => (
                   <div key={index} className="flex items-center gap-2">
                     <input
                       type="time"


### PR DESCRIPTION
## Summary

Fixes critical crash when editing therapist profiles with null/undefined availability data.

## Problem

The therapist profile edit form crashed with `TypeError: Cannot read properties of undefined (reading 'map')` when attempting to edit therapists whose `availability` field was null or undefined in the database.

**Root cause:** The `availability` JSONB field can be null, but the UI code assumed it would always be a properly structured object with all days defined.

## Changes

### 1. AdminTherapistsView.tsx (line 361)
- **Before:** `availability: editingTherapist.availability as any`
- **After:** Proper null validation with fallback to empty availability structure
- Removes unsafe `as any` type assertion

### 2. TherapistProfileForm.tsx (line 607)
- **Before:** `{availability[day].map((slot, index) => (`
- **After:** `{(availability[day] || []).map((slot, index) => (`
- Adds defensive null coalescing to prevent crash if day is undefined

### 3. TherapistProfileForm.tsx (lines 84-88)
- **Improved:** State initialization with proper typeof check
- Ensures availability is always initialized to valid structure

## Testing

- ✅ Type-check passes
- ✅ Lint passes (only pre-existing warnings)
- ✅ Defensive checks prevent crashes with null data
- ✅ Form initializes correctly with empty availability

## Impact

- Unblocks admin users from editing therapist profiles
- Gracefully handles edge cases with missing/malformed data
- Maintains type safety without using `any`

Resolves #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)