### PR TITLE
fix(auth): redirect therapists to /dashboard instead of /dashboard/therapist

### DIFF
--- a/src/app/[locale]/dev-login/page.tsx
+++ b/src/app/[locale]/dev-login/page.tsx
@@ -24,7 +24,7 @@ const DEV_USERS = [
   },
   {
     role: 'Therapist',
-    redirectPath: '/dashboard/therapist',
+    redirectPath: '/dashboard',
     email: 'dr.sarah.johnson@brightfutures.test',
     name: 'Dr. Sarah Johnson',
     description: 'ABA specialist, manage clients, appointments, session notes',


### PR DESCRIPTION
## Summary
- Fixed therapist sidebar not appearing by correcting redirect path
- Changed therapist redirect from `/dashboard/therapist` to `/dashboard` in dev-login page

## Root Cause
Therapists were redirected to `/dashboard/therapist` (simple test page without shell/sidebar) instead of `/dashboard` (role-based dashboard with proper layout).

All other roles (admin, billing, receptionist) already redirect to `/dashboard`. The `/dashboard/page.tsx` handles role-based rendering for all roles including therapists by showing TherapistDashboard component.

## Changes
- `src/app/[locale]/dev-login/page.tsx`: Changed therapist redirectPath from `/dashboard/therapist` to `/dashboard`

## Test Plan
- [x] Type-check passed
- [x] Lint passed (only pre-existing warnings)
- [ ] Manual test: Sign in as therapist via dev-login
- [ ] Verify sidebar appears with correct navigation items
- [ ] Verify TherapistDashboard component renders

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)